### PR TITLE
Updated mpl deprecation import for mpl 3.8

### DIFF
--- a/skymap/__init__.py
+++ b/skymap/__init__.py
@@ -14,5 +14,5 @@ from skymap.survey import SurveySkymap,SurveyMcBryde,SurveyOrtho
 from skymap.survey import DESSkymap, BlissSkymap
 
 import warnings
-from matplotlib.cbook import MatplotlibDeprecationWarning
+from matplotlib import MatplotlibDeprecationWarning
 warnings.filterwarnings("ignore",category=MatplotlibDeprecationWarning)


### PR DESCRIPTION
Hello - I ran into an issue where `skymap` imports `MatplolibDeprecationWarning` from a deprecated location that was removed in `matplotlib` 3.8.  This fix updates the import as suggested by the `matplotlib` warning; this resolved the problem in my use case.